### PR TITLE
Use model url from inherited model

### DIFF
--- a/src/wagtailbakery/views.py
+++ b/src/wagtailbakery/views.py
@@ -79,7 +79,7 @@ class WagtailBakeryView(BuildableDetailView):
 
     def get_url(self, obj):
         """Return Wagtail page url instead of Django's get_absolute_url."""
-        return obj.url
+        return obj.specific.url
 
     def get_path(self, obj):
         """Return Wagtail path to page."""

--- a/tests/integration/test_routablepagemixin.py
+++ b/tests/integration/test_routablepagemixin.py
@@ -22,4 +22,4 @@ def test_page_has_multiple_routes(site):
 
     # Build static files
     management.call_command('build', '--skip-static', '--skip-media')
-    assert os.path.exists(os.path.join(settings.BUILD_DIR, 'index.html'))
+    assert os.path.exists(os.path.join(settings.BUILD_DIR, 'eventpage', 'page', 'index.html'))

--- a/tests/models.py
+++ b/tests/models.py
@@ -30,3 +30,7 @@ class EventPage(RoutablePageMixin, Page):
 
     def get_static_site_paths(self):
         return super(EventPage, self).get_static_site_paths()
+
+    @property
+    def url(self):
+        return '/eventpage/{}'.format(self.slug)


### PR DESCRIPTION
Hi,
I'm using a model inherited from `Page`, which has a custom way how its URL is generated/resolved. In such case the `get_url()` method doesn't work since it's using the `url` property from the default model.

Using `model.specific.url` would fix this issue for me.