### PR TITLE
Update Test Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,31 +9,39 @@ matrix:
       env: TOXENV=isort
     # Tests
     - python: 3.5
+      env: TOXENV=py35-django21-wagtail27
+    - python: 3.5
       env: TOXENV=py35-django22-wagtail27
     - python: 3.6
       env: TOXENV=py36-django22-wagtail27
-    - python: 3.7
-      env: TOXENV=py37-django20-wagtail26
-    - python: 3.7
-      env: TOXENV=py37-django20-wagtail27
-    - python: 3.7
-      env: TOXENV=py37-django21-wagtail26
-    - python: 3.7
-      env: TOXENV=py37-django21-wagtail27
-    - python: 3.7
-      env: TOXENV=py37-django22-wagtail26
+    - python: 3.6
+      env: TOXENV=py36-django30-wagtail28
+    - python: 3.6
+      env: TOXENV=py36-django30-wagtail29
     - python: 3.7
       env: TOXENV=py37-django22-wagtail27
-    # Only testing Django 2.2 & Wagtail 2.7 (instead of all Django/Wagtail combinations)
+    - python: 3.7
+      env: TOXENV=py37-django30-wagtail28
+    - python: 3.7
+      env: TOXENV=py37-django30-wagtail29
+    # Only testing Django 2.2+ (instead of all Django/Wagtail combinations)
     # against Python 3.8 as Django<=2.2 doesn't officially support Python 3.8
     - python: 3.8
       env: TOXENV=py38-django22-wagtail27
+    - python: 3.8
+      env: TOXENV=py38-django22-wagtail28
+    - python: 3.8
+      env: TOXENV=py38-django30-wagtail28
+    - python: 3.8
+      env: TOXENV=py38-django22-wagtail29
+    - python: 3.8
+      env: TOXENV=py38-django30-wagtail29
     # Future (Should be in `allow_failures`)
-    - python: 3.7
-      env: TOXENV=py37-django22-wagtailmaster
+    - python: 3.8
+      env: TOXENV=py38-django30-wagtailmaster
   allow_failures:
     # Allow failures against Wagtail master
-    - env: TOXENV=py37-django22-wagtailmaster
+    - env: TOXENV=py38-django30-wagtailmaster
 cache:
   directories:
     - $HOME/.cache/pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/wagtail/wagtail-bakery/compare/0.4.0...HEAD)
 
-...
+### Removed
+
+- Drop support for Wagtail < 2.7
 
 ## [0.4.0](https://github.com/wagtail/wagtail-bakery/compare/0.3.0...0.4.0)
 

--- a/examples/aws/example/celery.py
+++ b/examples/aws/example/celery.py
@@ -1,8 +1,7 @@
 import os
 
-from django.conf import settings
-
 from celery import Celery
+from django.conf import settings
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'example.settings')
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ skip_install=true
 deps=flake8
 
 [testenv:isort]
-commands=isort --check-only --diff --recursive {[variables]linting_folders}
+commands=isort --check-only --diff {[variables]linting_folders}
 basepython=python3.7
 skip_install=true
 deps=isort

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,18 @@
 linting_folders=src/wagtailbakery/ tests/ examples/
 
 [tox]
-envlist=py{35,36,37,38}-django{20,21,22}-wagtail{26,27,master}
+envlist=py{35,36,37,38}-django{20,21,22,30}-wagtail{27,28,29,master}
 
 [testenv]
 commands=py.test --cov=wagtailbakery --cov-report=xml {posargs}
 deps=
-  django20: django>=2.0,<2.1
-  django21: django>=2.1,<2.2
-  django22: django>=2.2,<2.3
-  wagtail26: wagtail>=2.6,<2.7
-  wagtail27: wagtail>=2.7rc2,<2.8
+  django20: django>=2.0,<2.1     # WT 2.7
+  django21: django>=2.1,<2.2     # WT 2.7, 2.8
+  django22: django>=2.2,<2.3     # WT 2.7, 2.8. 2.9
+  django30: django>=3.0,<3.1     # WT      2.8, 2.9
+  wagtail27: wagtail>=2.7,<2.8   # LTS
+  wagtail28: wagtail>=2.8,<2.9   # Current -1
+  wagtail29: wagtail>=2.9,<2.10  # Current
   wagtailmaster: git+https://github.com/wagtail/wagtail.git@master#egg=Wagtail
 extras=test
 


### PR DESCRIPTION
According to our [supported version policy](https://github.com/wagtail/wagtail-bakery#supported-versions), drop support for Wagtail 2.6 and "add" support for Wagtail 2.8 and 2.9.

I leave add in quotes because as far as I can see, it works but it generates deprecation warning which I'll address in a separate PR (tracked in #53)