### PR TITLE
Add Circle CI config for Nightly Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+jobs:
+  nightly-wagtail-test:
+    docker:
+      - image: circleci/python:3.8
+    steps:
+      - checkout
+      - run: git clone git@github.com:wagtail/wagtail.git
+
+      # Install your plugin with its testing requirements. Update this line
+      - run: pip install -e .[testing]
+      # Replace Wagtail with the one checked out from git
+      - run: pip install ./wagtail
+
+      # Run the tests. Update this line too
+      - run: python testmanage.py test
+
+      - run:
+          when: on_fail
+          command: python ./.circleci/report_nightly_build_failure.py
+
+
+workflows:
+    version: 2
+
+    nightly:
+      jobs:
+        - nightly-wagtail-test
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only:
+                  - master

--- a/.circleci/report_nightly_build_failure.py
+++ b/.circleci/report_nightly_build_failure.py
@@ -1,0 +1,18 @@
+"""
+Called by CircleCI when the nightly build fails.
+
+This reports an error to the #nightly-build-failures Slack channel.
+"""
+import os
+import requests
+
+if 'SLACK_WEBHOOK_URL' in os.environ:
+    print("Reporting to #nightly-build-failures slack channel")
+    response = requests.post(os.environ['SLACK_WEBHOOK_URL'], json={
+        "text": "A Nightly build failed. See " + os.environ['CIRCLE_BUILD_URL'],
+    })
+
+    print("Slack responded with:", response)
+
+else:
+    print("Unable to report to #nightly-build-failures slack channel because SLACK_WEBHOOK_URL is not set")


### PR DESCRIPTION
Following the procedure for [Nightly testing of official plugins](https://github.com/wagtail/wagtail/wiki/Nightly-testing-of-official-plugins).

@kaedroho, I do not seem to have the rights to configure the project on Circle CI. Can you set `SLACK_WEBHOOK_URL` for `wagtail-bakery` for me? After that, we should be able to merge this PR.