### PR TITLE
Fix Factory-Boy incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = [
 ]
 
 test_requires = [
-    'factory-boy',
+    'factory-boy<3',
     'flake8',
     'isort',
     'pytest',


### PR DESCRIPTION
Factory-Boy 3.0 introduces some [breaking changes](https://factoryboy.readthedocs.io/en/stable/changelog.html#id3).

Despite the upgrade being simple enough (by replacing some imports)
we cannot update just yet as it also drops supports for Django 2.1
which we currently support since we support Wagtail 2.7.

As soon as Wagtail 2.11 LTS is released (due in November 2020),
we can drop support for Wagtail 2.7 LTS and therefore Django 2.1
which will allow us to upgrade Factory-Boy.