### PR TITLE
Fix for Wagtail 2.11a0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/wagtail/wagtail-bakery/compare/0.4.0...HEAD)
 
+### Added
+
+- Compatibility with Wagtail 2.11 (#58)
+
 ### Removed
 
 - Drop support for Wagtail < 2.7

--- a/examples/aws/example/settings.py
+++ b/examples/aws/example/settings.py
@@ -75,7 +75,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/examples/multisite/example/settings.py
+++ b/examples/multisite/example/settings.py
@@ -70,7 +70,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/examples/multisite/example/templates/base.html
+++ b/examples/multisite/example/templates/base.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static wagtailcore_tags %}
 
 <!DOCTYPE HTML>
 <html>
@@ -18,7 +18,8 @@
         {% endblock %}
         {% block title %}
         <h1>{{ self.title }}</h1>
-        <h2>{{ request.site.hostname }}</h2>
+        {% wagtail_site as current_site %}
+        <h2>{{ current_site.hostname }}</h2>
         {% endblock %}
         {% block content %}{% endblock %}
     </body>

--- a/examples/site/example/settings.py
+++ b/examples/site/example/settings.py
@@ -70,7 +70,6 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 

--- a/src/wagtailbakery/api_views.py
+++ b/src/wagtailbakery/api_views.py
@@ -5,6 +5,7 @@ import os
 from bakery.views import BuildableMixin
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.core.models import Page, Site
 
@@ -101,7 +102,8 @@ class APIDetailView(BuildableMixin):
     def get_content(self, obj):
         # Create a dummy request
         request = self.create_request('/?format=json&fields=*')
-        request.site = Site.objects.get(is_default_site=True)
+        if WAGTAIL_VERSION < (2, 9):
+            request.site = Site.objects.get(is_default_site=True)
         request.wagtailapi_router = WagtailAPIRouter('')
 
         response = self.endpoint_class.as_view({'get': 'detail_view'})(request, pk=obj.pk)
@@ -147,7 +149,8 @@ class PagesAPIListingView(APIListingView):
             url = '/?format=json&fields=*&limit={}&offset={}'.format(self.results_per_page, self.results_per_page * page_num)
 
         request = self.create_request(url)
-        request.site = Site.objects.get(is_default_site=True)
+        if WAGTAIL_VERSION < (2, 9):
+            request.site = Site.objects.get(is_default_site=True)
         request.wagtailapi_router = WagtailAPIRouter('')
         response = PagesAPIViewSet.as_view({'get': 'listing_view'})(request)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 from django.conf import settings
+from wagtail import VERSION as WAGTAIL_VERSION
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -21,10 +22,15 @@ def pytest_configure():
         'wagtail.admin',
         'wagtail.core',
     ]
-    wagtail_middleware = [
-        'wagtail.core.middleware.SiteMiddleware',
-        'wagtail.contrib.redirects.middleware.RedirectMiddleware',
-    ]
+    if WAGTAIL_VERSION >= (2, 9):
+        wagtail_middleware = [
+            'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+        ]
+    else:
+        wagtail_middleware = [
+            'wagtail.core.middleware.SiteMiddleware',
+            'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+        ]
 
     settings.configure(
         DATABASES={

--- a/tests/integration/test_api_views.py
+++ b/tests/integration/test_api_views.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtailbakery.api_views import (
     PagesAPIDetailView, PagesAPIListingView, TypedPagesAPIListingView)
@@ -9,6 +10,9 @@ from ..models import EventPage
 
 DEFAULT_PAGE_FIELDS = {'id', 'meta', 'title'}
 DEFAULT_PAGE_META_FIELDS = {'type', 'show_in_menus', 'search_description', 'first_published_at', 'slug', 'html_url', 'seo_title'}
+
+if WAGTAIL_VERSION >= (2, 11):
+    DEFAULT_PAGE_META_FIELDS.add('locale')
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
* Remove SiteMiddleware from examples
* Don't pass request.site to API views on >=2.9, as it is no longer required
* Update API tests to expect a 'locale' field on >=2.11