### PR TITLE
Add 'alias_of' field to tests

### DIFF
--- a/tests/integration/test_api_views.py
+++ b/tests/integration/test_api_views.py
@@ -14,6 +14,9 @@ DEFAULT_PAGE_META_FIELDS = {'type', 'show_in_menus', 'search_description', 'firs
 if WAGTAIL_VERSION >= (2, 11):
     DEFAULT_PAGE_META_FIELDS.add('locale')
 
+if WAGTAIL_VERSION >= (2, 16):
+    DEFAULT_PAGE_META_FIELDS.add('alias_of')
+
 
 @pytest.mark.django_db
 def test_wagtail_bakery_pages_api_detail_view(page_tree):


### PR DESCRIPTION
Prevent tests from failing because later Wagtail versions will introduce the `alias_of` meta field to the api. See commit https://github.com/wagtail/wagtail/commit/195b1a178a4f4b57eaf316a6e582e8cf3e832782