### PR TITLE
Update supported Wagtail versions to 2.14 and 2.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 install_requires = [
     'django-bakery~=0.12.7',
-    'wagtail>=2.10',
+    'wagtail>=2.14',
 ]
 
 test_requires = [
@@ -40,9 +40,9 @@ setup(
         'Framework :: Wagtail :: 2',
         'Operating System :: Unix',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,20 +3,19 @@ linting_folders=src/wagtailbakery/ tests/ examples/
 
 [tox]
 envlist=
-  py38-django{22,30,31}-wagtail211,                # Wagtail LTS - latest Python - all Django
-  py39-django{22,30,31,32}-wagtail213,             # Wagtail current - latest Python - all Django
-  py{36,37,38}-django32-wagtail213,                # Wagtail current - all Python  - latest Django
+  py310-django{30,31,32}-wagtail215,               # Wagtail LTS - latest Python - all Django
+  py39-django{22,30,31,32}-wagtail214,             # Wagtail current - latest Python - all Django
+  py{36,37,38,39}-django32-wagtail214,             # Wagtail current - all Python  - latest Django
   wagtailmain                                      # Wagtail main latest compatible version
 
 [testenv]
 commands=py.test --cov=wagtailbakery --cov-report=xml {posargs}
 deps=
-  django22: django>=2.2,<2.3       # WT 2.11, 2.13
-  django30: django>=3.0,<3.1       # WT 2.11, 2.13
-  django31: django>=3.1,<3.2       # WT 2.11, 2.13
-  django32: django>=3.2,<3.3       # WT 2.13
-  wagtail211: wagtail>=2.11,<2.12  # Current LTS
-  wagtail213: wagtail>=2.13,<2.14  # Current latest stable
+  django30: django>=3.0,<3.1       # WT 2.14, 2.15
+  django31: django>=3.1,<3.2       # WT 2.14, 2.15
+  django32: django>=3.2,<3.3       # WT 2.14, 2.15
+  wagtail214: wagtail>=2.14,<2.15  # Current latest stable
+  wagtail215: wagtail>=2.15,<2.16  # Current LTS
 extras=test
 
 [testenv:wagtailmain]


### PR DESCRIPTION
See https://docs.wagtail.io/en/latest/releases/upgrading.html#compatible-django-python-versions