### PR TITLE
Add option to ignore objects that fail to build

### DIFF
--- a/src/wagtailbakery/views.py
+++ b/src/wagtailbakery/views.py
@@ -91,8 +91,14 @@ class WagtailBakeryView(BuildableDetailView):
         self.request = RequestFactory(
             SERVER_NAME=site.hostname).get(self.get_url(obj))
         self.set_kwargs(obj)
-        path = self.get_build_path(obj)
-        self.build_file(path, self.get_content(obj))
+        try:
+            path = self.get_build_path(obj)
+            self.build_file(path, self.get_content(obj))
+        except Exception as exc:
+            if settings.BAKERY_IGNORE_OBJECTS_THAT_FAILED_TO_BUILD:
+                logger.error("Failed to build object %s: %s" % (obj, exc))
+            else:
+                raise exc
 
     def build_queryset(self):
         for item in self.get_queryset().all():


### PR DESCRIPTION
Hi! I was having an issue where one of my object paths contained a string that was longer than the maximum filename length on ext filesystems. Because of this one object path, my entire bakery run was failing - and in my case, I would have preferred for that single missing file to be omitted from the generated static site, rather than to have had the entire build fail. I've opened this PR to add a setting to log an error and skip the file, rather than fail. The default behaviour is the pre-existing behaviour - the new skipping is opt-in.

I've tested this on my wagtail and it works as expected. However, I would greatly appreciate any feedback or advice you have. In particular, I have the following questions:

1. What's a good way to prepare a test case for this?
2. Is there a more specific exception I should catch? (see below)
3. Better to log a warning? Or use f strings there? I assume not, for backwards python compatibility?

The exception I was getting was an OSError number 36 - filename too long - in the `get_build_path` function. I suspect that it's better to catch a broader error in that function or in the subsequent calls to `get_content` and `build_file` - but maybe I've gone too broad in catching _anything_?