### PR TITLE
Bump django-bakery to support Django 4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 install_requires = [
-    'django-bakery~=0.12.7',
+    'django-bakery~=0.13.1',
     'wagtail>=2.10',
 ]
 


### PR DESCRIPTION
This PR bumps the `django-bakery` dependency in the hopes that `wagtail-bakery` can also support Django 4. If CI/CD steps go well, I'll also update references to Django 4 support within the repo!

