### PR TITLE
Fix support for Django 4.0 and update test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,14 @@ jobs:
         toxenv: ["py"]
         include:
           # Linting
-          - python: 3.8
+          - python: "3.8"
             toxenv: flake8
             experimental: false
-          - python: 3.8
+          - python: "3.8"
             toxenv: isort
             experimental: false
             # Future Wagtail release from main branch (allowed to fail)
-          - python: 3.10
+          - python: "3.10"
             toxenv: wagtailmain
             experimental: true
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9"]
+        python: ["3.8", "3.9", "3.10"]
         experimental: [false]
         toxenv: ["py"]
         include:
@@ -27,7 +27,7 @@ jobs:
             toxenv: isort
             experimental: false
             # Future Wagtail release from main branch (allowed to fail)
-          - python: 3.9
+          - python: 3.10
             toxenv: wagtailmain
             experimental: true
     steps:
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
-          python -m pip install tox tox-py "Django<4"
+          python -m pip install tox tox-py
 
         # This step runs only for jobs NOT in the include matrix
       - name: Run tox targets for Python ${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ A set of helpers for baking your Django Wagtail site out as flat files.
 
 Wagtail-bakery is built on top of [Django bakery](https://github.com/datadesk/django-bakery). Please read their [documentation](https://django-bakery.readthedocs.io/en/latest/) for detailed configuration and how to build default Django flat files. Yes. Wagtail-bakery is not limited to build Wagtail pages specifically, mixed content is possible!
 
-## Compatibility note
-
-As of July 2022, django-bakery lacks support for Django 4.x. You are advised to use Django 3.2.x (LTS). Alternatively, see [wagtail-freezer](https://github.com/gasman/wagtail-freezer) for a Django 4 compatible replacement.
 
 ## Features
 

--- a/examples/aws/example/urls.py
+++ b/examples/aws/example/urls.py
@@ -1,33 +1,33 @@
 """example URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/4.1/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import path, include
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 import os
 
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^cms/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'^pages/', include(wagtail_urls)),
-    url(r'', include(wagtail_urls)),
+    path('admin/', admin.site.urls),
+    path('cms/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
+    path('pages/', include(wagtail_urls)),
+    path('', include(wagtail_urls)),
 ]
 
 if settings.DEBUG:

--- a/examples/multisite/example/urls.py
+++ b/examples/multisite/example/urls.py
@@ -1,33 +1,33 @@
 """example URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.10/topics/http/urls/
+    https://docs.djangoproject.com/en/4.1/topics/http/urls/
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    1. Import the include() function: from django.urls import path, include
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 import os
 
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^cms/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'^pages/', include(wagtail_urls)),
-    url(r'', include(wagtail_urls)),
+    path('admin/', admin.site.urls),
+    path('cms/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
+    path('pages/', include(wagtail_urls)),
+    path('', include(wagtail_urls)),
 ]
 
 if settings.DEBUG:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 install_requires = [
     'django-bakery~=0.13.1',
-    'wagtail>=2.10',
+    'wagtail>=2.15',
 ]
 
 test_requires = [

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 install_requires = [
-    'django-bakery~=0.12.7',
+    'django-bakery~=0.13.1',
     'wagtail>=2.10',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,11 @@ setup(
         'Framework :: Django',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 2',
+        'Framework :: Wagtail :: 4',
         'Operating System :: Unix',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'', include(wagtail_urls)),
+    path('admin/', include(wagtailadmin_urls)),
+    path('', include(wagtail_urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -3,26 +3,28 @@ linting_folders=src/wagtailbakery/ tests/ examples/
 
 [tox]
 envlist=
-  py38-django{22,30,31}-wagtail211,                # Wagtail LTS - latest Python - all Django
-  py39-django{22,30,31,32}-wagtail213,             # Wagtail current - latest Python - all Django
-  py{36,37,38}-django32-wagtail213,                # Wagtail current - all Python  - latest Django
+  py310-django{32}-wagtail215,                     # Wagtail 2.15 LTS - latest supported Python - Django LTS
+  py{38,39,310}-django41-wagtail40,                # Wagtail 4.0 - all Python - latest Django
+  py310-django{32,40,41}-wagtail41,                # Wagtail 4.1 LTS - latest Python - all Django
   wagtailmain                                      # Wagtail main latest compatible version
 
 [testenv]
 commands=py.test --cov=wagtailbakery --cov-report=xml {posargs}
 deps=
-  django22: django>=2.2,<2.3       # WT 2.11, 2.13
-  django30: django>=3.0,<3.1       # WT 2.11, 2.13
-  django31: django>=3.1,<3.2       # WT 2.11, 2.13
-  django32: django>=3.2,<3.3       # WT 2.13
-  wagtail211: wagtail>=2.11,<2.12  # Current LTS
-  wagtail213: wagtail>=2.13,<2.14  # Current latest stable
+  django32: django>=3.2,<3.3       # WT 2.15 LTS
+  django40: django>=4.0,<4.1       # WT 4.0, WT 4.1 LTS
+  django41: django>=4.1,<4.2       # WT 4.0, WT 4.1 LTS
+  wagtail215: wagtail>=2.15,<2.16  # Old LTS
+  wagtail40: wagtail>=4.0,<4.1  # Current latest
+
+  ; TODO: use final release when available
+  wagtail41: wagtail==4.1rc1  # Upcoming LTS
 extras=test
 
 [testenv:wagtailmain]
 commands=py.test --cov=wagtailbakery --cov-report=xml {posargs}
 deps=
-  django>=3.2,<3.3
+  django>=4.1,<4.2
   git+https://github.com/wagtail/wagtail.git@main#egg=Wagtail
 extras=test
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,7 @@ deps=
   django41: django>=4.1,<4.2       # WT 4.0, WT 4.1 LTS
   wagtail215: wagtail>=2.15,<2.16  # Old LTS
   wagtail40: wagtail>=4.0,<4.1  # Current latest
-
-  ; TODO: use final release when available
-  wagtail41: wagtail==4.1rc1  # Upcoming LTS
+  wagtail41: wagtail>=4.1rc1,<4.2  # Current LTS
 extras=test
 
 [testenv:wagtailmain]


### PR DESCRIPTION
This PR supersedes #72, commits retained because the original author deserves the attribution. Thanks for setting this in motion @AetherUnbound!

This PR updates the [django-bakery](https://github.com/palewire/django-bakery) dependency to 0.13.1 which includes support for Django 4.0. This means there is nothing holding us back anymore from supporting Django 4.0 and higher.

I've fixed the remaining compatibility issues with Django 4 and updated the testing matrix to the latest supported Django / Python / Wagtail versions.

Notably, this PR drops support for:
- Django 2.2, 3.0 and 3.1
- Wagtail 2.14 and older
- Python 3.6 and 3.7 (3.7 is quite old and not supported by Django 4.1)

Support for the following Django / Python / Wagtail versions has been added:
- Wagtail 2.15 LTS; v4.0 and the upcoming v4.1 LTS release.
  - v3.0 is not explicitly supported because it is near end of support but should probably work.
- Django 4.0 and 4.1
- Python 3.10

All tests pass for me locally but I have not given this a test drive in a real project. We should verify everything still works as expected before making a new release.

